### PR TITLE
Code quality fix - Performance - Method invokes inefficient Number constructor; use static valueOf instead.

### DIFF
--- a/src/main/java/com/cloudhopper/smpp/pdu/Pdu.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/Pdu.java
@@ -81,7 +81,7 @@ public abstract class Pdu {
     }
 
     public void setCommandLength(int value) {
-        this.commandLength = new Integer(value);
+        this.commandLength = Integer.valueOf(value);
     }
 
     public int getCommandLength() {
@@ -124,7 +124,7 @@ public abstract class Pdu {
     }
 
     public void setSequenceNumber(int value) {
-        this.sequenceNumber = new Integer(value);
+        this.sequenceNumber = Integer.valueOf(value);
     }
 
     public int getSequenceNumber() {

--- a/src/main/java/com/cloudhopper/smpp/transcoder/DefaultPduTranscoderContext.java
+++ b/src/main/java/com/cloudhopper/smpp/transcoder/DefaultPduTranscoderContext.java
@@ -50,7 +50,7 @@ public class DefaultPduTranscoderContext implements PduTranscoderContext {
             resultMessage = overrideContext.lookupResultMessage(commandStatus);
         }
         if (resultMessage == null) {
-            resultMessage = SmppConstants.STATUS_MESSAGE_MAP.get(new Integer(commandStatus));
+            resultMessage = SmppConstants.STATUS_MESSAGE_MAP.get(Integer.valueOf(commandStatus));
         }
         return resultMessage;
     }
@@ -62,7 +62,7 @@ public class DefaultPduTranscoderContext implements PduTranscoderContext {
             tagName = overrideContext.lookupTlvTagName(tag);
         }
         if (tagName == null) {
-            tagName = SmppConstants.TAG_NAME_MAP.get(new Short(tag));
+            tagName = SmppConstants.TAG_NAME_MAP.get(Short.valueOf(tag));
         }
         return tagName;
     }

--- a/src/main/java/com/cloudhopper/smpp/util/ConcurrentCommandStatusCounter.java
+++ b/src/main/java/com/cloudhopper/smpp/util/ConcurrentCommandStatusCounter.java
@@ -51,7 +51,7 @@ public class ConcurrentCommandStatusCounter {
     }
     
     public int get(int commandStatus) {
-        Integer key = new Integer(commandStatus);
+        Integer key = Integer.valueOf(commandStatus);
         AtomicInteger val = map.get(key);
         if (val == null) {
             return -1;
@@ -61,7 +61,7 @@ public class ConcurrentCommandStatusCounter {
     }
     
     public int incrementAndGet(int commandStatus) {
-        Integer key = new Integer(commandStatus);
+        Integer key = Integer.valueOf(commandStatus);
         AtomicInteger val = map.get(key);
         if (val == null) {
             val = new AtomicInteger(0);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
findbugs:DM_NUMBER_CTOR - Performance - Method invokes inefficient Number constructor; use static valueOf instead.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/findbugs:DM_NUMBER_CTOR

Please let me know if you have any questions.

Faisal Hameed
