### PR TITLE
Code quality fix - Useless parentheses around expressions should be removed to prevent any misunderstanding.

### DIFF
--- a/src/main/java/com/cloudhopper/smpp/impl/DefaultPduAsyncResponse.java
+++ b/src/main/java/com/cloudhopper/smpp/impl/DefaultPduAsyncResponse.java
@@ -70,7 +70,7 @@ public class DefaultPduAsyncResponse implements PduAsyncResponse {
         if (responseTime == 0 || future.getWindowSize() == 0) {
             return 0;
         }
-        return (responseTime / future.getWindowSize());
+        return responseTime / future.getWindowSize();
     }
 
     @Override

--- a/src/main/java/com/cloudhopper/smpp/impl/DefaultSmppServer.java
+++ b/src/main/java/com/cloudhopper/smpp/impl/DefaultSmppServer.java
@@ -223,17 +223,17 @@ public class DefaultSmppServer implements SmppServer, DefaultSmppServerMXBean {
     
     @Override
     public boolean isStarted() {
-        return (this.serverChannel != null && this.serverChannel.isBound());
+        return this.serverChannel != null && this.serverChannel.isBound();
     }
 
     @Override
     public boolean isStopped() {
-        return (this.serverChannel == null);
+        return this.serverChannel == null;
     }
 
     @Override
     public boolean isDestroyed() {
-        return (this.serverBootstrap == null);
+        return this.serverBootstrap == null;
     }
     
     @Override

--- a/src/main/java/com/cloudhopper/smpp/impl/DefaultSmppSession.java
+++ b/src/main/java/com/cloudhopper/smpp/impl/DefaultSmppSession.java
@@ -150,7 +150,7 @@ public class DefaultSmppSession implements SmppServerSession, SmppSessionChannel
         this.configuration = configuration;
         this.channel = channel;
         this.boundTime = new AtomicLong(0);
-        this.sessionHandler = (sessionHandler == null ? new DefaultSmppSessionHandler(logger) : sessionHandler);
+        this.sessionHandler = sessionHandler == null ? new DefaultSmppSessionHandler(logger) : sessionHandler;
         this.sequenceNumber = new SequenceNumber();
         // always "wrap" the custom pdu transcoder context with a default one
         this.transcoder = new DefaultPduTranscoder(new DefaultPduTranscoderContext(this.sessionHandler));
@@ -245,32 +245,32 @@ public class DefaultSmppSession implements SmppServerSession, SmppSessionChannel
 
     @Override
     public boolean areOptionalParametersSupported() {
-        return (this.interfaceVersion >= SmppConstants.VERSION_3_4);
+        return this.interfaceVersion >= SmppConstants.VERSION_3_4;
     }
 
     @Override
     public boolean isOpen() {
-        return (this.state.get() == STATE_OPEN);
+        return this.state.get() == STATE_OPEN;
     }
 
     @Override
     public boolean isBinding() {
-        return (this.state.get() == STATE_BINDING);
+        return this.state.get() == STATE_BINDING;
     }
 
     @Override
     public boolean isBound() {
-        return (this.state.get() == STATE_BOUND);
+        return this.state.get() == STATE_BOUND;
     }
 
     @Override
     public boolean isUnbinding() {
-        return (this.state.get() == STATE_UNBINDING);
+        return this.state.get() == STATE_UNBINDING;
     }
 
     @Override
     public boolean isClosed() {
-        return (this.state.get() == STATE_CLOSED);
+        return this.state.get() == STATE_CLOSED;
     }
 
     @Override
@@ -302,7 +302,7 @@ public class DefaultSmppSession implements SmppServerSession, SmppSessionChannel
     
     @Override
     public boolean hasCounters() {
-        return (this.counters != null);
+        return this.counters != null;
     }
     
     @Override
@@ -626,7 +626,7 @@ public class DefaultSmppSession implements SmppServerSession, SmppSessionChannel
                 WindowFuture<Integer,PduRequest,PduResponse> future = this.sendWindow.complete(receivedPduSeqNum, responsePdu);
                 if (future != null) {
                     logger.trace("Found a future in the window for seqNum [{}]", receivedPduSeqNum);
-                    this.countReceiveResponsePdu(responsePdu, future.getOfferToAcceptTime(), future.getAcceptToDoneTime(), (future.getAcceptToDoneTime() / future.getWindowSize()));
+                    this.countReceiveResponsePdu(responsePdu, future.getOfferToAcceptTime(), future.getAcceptToDoneTime(), future.getAcceptToDoneTime() / future.getWindowSize());
                     
                     // if this isn't null, we found a match to a request
                     int callerStateHint = future.getCallerStateHint();
@@ -947,7 +947,7 @@ public class DefaultSmppSession implements SmppServerSession, SmppSessionChannel
 
     @Override
     public boolean isWindowMonitorEnabled() {
-        return (this.monitorExecutor != null && this.configuration.getWindowMonitorInterval() > 0);
+        return this.monitorExecutor != null && this.configuration.getWindowMonitorInterval() > 0;
     }
     
     @Override

--- a/src/main/java/com/cloudhopper/smpp/pdu/BaseSm.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/BaseSm.java
@@ -59,7 +59,7 @@ public abstract class BaseSm<R extends PduResponse> extends PduRequest<R> {
     }
 
     public int getShortMessageLength() {
-        return (this.shortMessage == null ? 0 : this.shortMessage.length);
+        return this.shortMessage == null ? 0 : this.shortMessage.length;
     }
 
     public byte[] getShortMessage() {

--- a/src/main/java/com/cloudhopper/smpp/pdu/Pdu.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/Pdu.java
@@ -73,7 +73,7 @@ public abstract class Pdu {
     }
 
     public boolean hasCommandLengthCalculated() {
-        return (this.commandLength != null);
+        return this.commandLength != null;
     }
 
     public void removeCommandLength() {
@@ -116,7 +116,7 @@ public abstract class Pdu {
     }
 
     public boolean hasSequenceNumberAssigned() {
-        return (this.sequenceNumber != null);
+        return this.sequenceNumber != null;
     }
 
     public void removeSequenceNumber() {
@@ -206,7 +206,7 @@ public abstract class Pdu {
      * @return True if exists, otherwise false
      */
     public boolean hasOptionalParameter(short tag) {
-        return (this.findOptionalParameter(tag) >= 0);
+        return this.findOptionalParameter(tag) >= 0;
     }
 
     protected int findOptionalParameter(short tag) {

--- a/src/main/java/com/cloudhopper/smpp/pdu/ReplaceSm.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/ReplaceSm.java
@@ -68,7 +68,7 @@ public class ReplaceSm extends PduRequest<ReplaceSmResp> {
     }
     
     public int getShortMessageLength() {
-        return (this.shortMessage == null ? 0 : this.shortMessage.length);
+        return this.shortMessage == null ? 0 : this.shortMessage.length;
     }
 
     public byte[] getShortMessage() {

--- a/src/main/java/com/cloudhopper/smpp/tlv/Tlv.java
+++ b/src/main/java/com/cloudhopper/smpp/tlv/Tlv.java
@@ -72,7 +72,7 @@ public class Tlv {
      * @return The "unsigned" length of this TLV's value
      */
     public int getUnsignedLength() {
-        return (value == null ? 0 : value.length);
+        return value == null ? 0 : value.length;
     }
 
     public short getLength() {

--- a/src/main/java/com/cloudhopper/smpp/type/LoggingOptions.java
+++ b/src/main/java/com/cloudhopper/smpp/type/LoggingOptions.java
@@ -45,7 +45,7 @@ public class LoggingOptions {
     }
 
     public boolean isLogPduEnabled() {
-        return ((this.option & LOG_PDU) > 0);
+        return (this.option & LOG_PDU) > 0;
     }
 
     public void setLogBytes(boolean value) {
@@ -57,6 +57,6 @@ public class LoggingOptions {
     }
 
     public boolean isLogBytesEnabled() {
-        return ((this.option & LOG_BYTES) > 0);
+        return (this.option & LOG_BYTES) > 0;
     }
 }

--- a/src/main/java/com/cloudhopper/smpp/util/PduUtil.java
+++ b/src/main/java/com/cloudhopper/smpp/util/PduUtil.java
@@ -58,11 +58,11 @@ public class PduUtil {
 
     static public boolean isRequestCommandId(int commandId) {
         // if the 31st bit is not set, this is a request
-        return ((commandId & SmppConstants.PDU_CMD_ID_RESP_MASK) == 0);
+        return (commandId & SmppConstants.PDU_CMD_ID_RESP_MASK) == 0;
     }
 
     static public boolean isResponseCommandId(int commandId) {
         // if the 31st bit is not set, this is a request
-        return ((commandId & SmppConstants.PDU_CMD_ID_RESP_MASK) == SmppConstants.PDU_CMD_ID_RESP_MASK);
+        return (commandId & SmppConstants.PDU_CMD_ID_RESP_MASK) == SmppConstants.PDU_CMD_ID_RESP_MASK;
     }
 }

--- a/src/main/java/com/cloudhopper/smpp/util/SmppUtil.java
+++ b/src/main/java/com/cloudhopper/smpp/util/SmppUtil.java
@@ -39,7 +39,7 @@ public class SmppUtil {
      * @return True if the option is set, otherwise false.
      */
     static public boolean isMessageTypeAnyDeliveryReceipt(byte esmClass) {
-        return ((esmClass & SmppConstants.ESM_CLASS_MT_MASK) > 0);
+        return (esmClass & SmppConstants.ESM_CLASS_MT_MASK) > 0;
     }
 
     /**
@@ -48,7 +48,7 @@ public class SmppUtil {
      * @return True if the option is set, otherwise false.
      */
     static public boolean isMessageTypeManualUserAcknowledgement(byte esmClass) {
-        return ((esmClass & SmppConstants.ESM_CLASS_MT_MASK) == SmppConstants.ESM_CLASS_MT_MANUAL_USER_ACK);
+        return (esmClass & SmppConstants.ESM_CLASS_MT_MASK) == SmppConstants.ESM_CLASS_MT_MANUAL_USER_ACK;
     }
 
     /**
@@ -57,7 +57,7 @@ public class SmppUtil {
      * @return True if the option is set, otherwise false.
      */
     static public boolean isMessageTypeEsmeDeliveryReceipt(byte esmClass) {
-        return ((esmClass & SmppConstants.ESM_CLASS_MT_MASK) == SmppConstants.ESM_CLASS_MT_ESME_DELIVERY_RECEIPT);
+        return (esmClass & SmppConstants.ESM_CLASS_MT_MASK) == SmppConstants.ESM_CLASS_MT_ESME_DELIVERY_RECEIPT;
     }
 
     /**
@@ -66,7 +66,7 @@ public class SmppUtil {
      * @return True if the option is set, otherwise false.
      */
     static public boolean isMessageTypeIntermediateDeliveryReceipt(byte esmClass) {
-        return ((esmClass & SmppConstants.ESM_CLASS_INTERMEDIATE_DELIVERY_RECEIPT_FLAG) == SmppConstants.ESM_CLASS_INTERMEDIATE_DELIVERY_RECEIPT_FLAG);
+        return (esmClass & SmppConstants.ESM_CLASS_INTERMEDIATE_DELIVERY_RECEIPT_FLAG) == SmppConstants.ESM_CLASS_INTERMEDIATE_DELIVERY_RECEIPT_FLAG;
     }
 
     /**
@@ -75,7 +75,7 @@ public class SmppUtil {
      * @return True if the option is set, otherwise false.
      */
     static public boolean isMessageTypeSmscDeliveryReceipt(byte esmClass) {
-        return ((esmClass & SmppConstants.ESM_CLASS_MT_MASK) == SmppConstants.ESM_CLASS_MT_SMSC_DELIVERY_RECEIPT);
+        return (esmClass & SmppConstants.ESM_CLASS_MT_MASK) == SmppConstants.ESM_CLASS_MT_SMSC_DELIVERY_RECEIPT;
     }
 
     /**
@@ -84,7 +84,7 @@ public class SmppUtil {
      * @return True if the option is set, otherwise false.
      */
     static public boolean isUserDataHeaderIndicatorEnabled(byte esmClass) {
-        return ((esmClass & SmppConstants.ESM_CLASS_UDHI_MASK) == SmppConstants.ESM_CLASS_UDHI_MASK);
+        return (esmClass & SmppConstants.ESM_CLASS_UDHI_MASK) == SmppConstants.ESM_CLASS_UDHI_MASK;
     }
 
     /**
@@ -93,7 +93,7 @@ public class SmppUtil {
      * @return True if the option is set, otherwise false.
      */
     static public boolean isReplyPathEnabled(byte esmClass) {
-        return ((esmClass & SmppConstants.ESM_CLASS_REPLY_PATH_MASK) == SmppConstants.ESM_CLASS_REPLY_PATH_MASK);
+        return (esmClass & SmppConstants.ESM_CLASS_REPLY_PATH_MASK) == SmppConstants.ESM_CLASS_REPLY_PATH_MASK;
     }
 
     /**
@@ -103,7 +103,7 @@ public class SmppUtil {
      * @return True if the option is set, otherwise false.
      */
     static public boolean isSmscDeliveryReceiptRequested(byte registeredDelivery) {
-        return ((registeredDelivery & SmppConstants.REGISTERED_DELIVERY_SMSC_RECEIPT_MASK) == SmppConstants.REGISTERED_DELIVERY_SMSC_RECEIPT_REQUESTED);
+        return (registeredDelivery & SmppConstants.REGISTERED_DELIVERY_SMSC_RECEIPT_MASK) == SmppConstants.REGISTERED_DELIVERY_SMSC_RECEIPT_REQUESTED;
     }
 
     /**
@@ -113,7 +113,7 @@ public class SmppUtil {
      * @return True if the option is set, otherwise false.
      */
     static public boolean isSmscDeliveryReceiptOnFailureRequested(byte registeredDelivery) {
-        return ((registeredDelivery & SmppConstants.REGISTERED_DELIVERY_SMSC_RECEIPT_MASK) == SmppConstants.REGISTERED_DELIVERY_SMSC_RECEIPT_ON_FAILURE);
+        return (registeredDelivery & SmppConstants.REGISTERED_DELIVERY_SMSC_RECEIPT_MASK) == SmppConstants.REGISTERED_DELIVERY_SMSC_RECEIPT_ON_FAILURE;
     }
 
     /**
@@ -122,7 +122,7 @@ public class SmppUtil {
      * @return True if the option is set, otherwise false.
      */
     static public boolean isIntermediateReceiptRequested(byte registeredDelivery) {
-        return ((registeredDelivery & SmppConstants.REGISTERED_DELIVERY_INTERMEDIATE_NOTIFICATION_MASK) == SmppConstants.REGISTERED_DELIVERY_INTERMEDIATE_NOTIFICATION_REQUESTED);
+        return (registeredDelivery & SmppConstants.REGISTERED_DELIVERY_INTERMEDIATE_NOTIFICATION_MASK) == SmppConstants.REGISTERED_DELIVERY_INTERMEDIATE_NOTIFICATION_REQUESTED;
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.

Faisal Hameed
