### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/com/cloudhopper/smpp/SmppConstants.java
+++ b/src/main/java/com/cloudhopper/smpp/SmppConstants.java
@@ -31,6 +31,8 @@ import java.util.Map;
  */
 public class SmppConstants {
 
+    private SmppConstants() {}
+    
     //
     // SMPP Data Types
     //

--- a/src/main/java/com/cloudhopper/smpp/channel/ChannelUtil.java
+++ b/src/main/java/com/cloudhopper/smpp/channel/ChannelUtil.java
@@ -30,6 +30,8 @@ import org.jboss.netty.channel.Channel;
  */
 public class ChannelUtil {
 
+    private ChannelUtil() {}
+    
     /**
      * Create a name for the channel based on the remote host's IP and port.
      */

--- a/src/main/java/com/cloudhopper/smpp/channel/SmppChannelConstants.java
+++ b/src/main/java/com/cloudhopper/smpp/channel/SmppChannelConstants.java
@@ -27,6 +27,8 @@ package com.cloudhopper.smpp.channel;
  */
 public class SmppChannelConstants {
 
+    private SmppChannelConstants() {}
+    
     public static final String PIPELINE_SERVER_CONNECTOR_NAME = "smppServerConnector";
 
     // default channel handler used only during connects

--- a/src/main/java/com/cloudhopper/smpp/util/ChannelBufferUtil.java
+++ b/src/main/java/com/cloudhopper/smpp/util/ChannelBufferUtil.java
@@ -37,6 +37,9 @@ import org.slf4j.LoggerFactory;
  * @author joelauer (twitter: @jjlauer or <a href="http://twitter.com/jjlauer" target=window>http://twitter.com/jjlauer</a>)
  */
 public class ChannelBufferUtil {
+    
+    private ChannelBufferUtil() {}
+    
     private static final Logger logger = LoggerFactory.getLogger(ChannelBufferUtil.class);
 
     /**

--- a/src/main/java/com/cloudhopper/smpp/util/DaemonExecutors.java
+++ b/src/main/java/com/cloudhopper/smpp/util/DaemonExecutors.java
@@ -30,6 +30,8 @@ import java.util.concurrent.ThreadFactory;
  */
 public class DaemonExecutors {
 
+    private DaemonExecutors() {}
+    
     /**
      * Utility method for creating a cached pool of "daemon" threads.  A daemon
      * thread does not limit the JVM from exiting if they aren't shutdown.

--- a/src/main/java/com/cloudhopper/smpp/util/PduUtil.java
+++ b/src/main/java/com/cloudhopper/smpp/util/PduUtil.java
@@ -29,6 +29,8 @@ import com.cloudhopper.smpp.type.Address;
  */
 public class PduUtil {
 
+    private PduUtil() {}
+    
     /**
      * Calculates size of a "C-String" by returning the length of the String
      * plus 1 (for the NULL byte).  If the parameter is null, will return 1.

--- a/src/main/java/com/cloudhopper/smpp/util/SmppSessionUtil.java
+++ b/src/main/java/com/cloudhopper/smpp/util/SmppSessionUtil.java
@@ -34,6 +34,9 @@ import org.slf4j.LoggerFactory;
  * @author joelauer (twitter: @jjlauer or <a href="http://twitter.com/jjlauer" target=window>http://twitter.com/jjlauer</a>)
  */
 public class SmppSessionUtil {
+    
+    private SmppSessionUtil() {}
+    
     private static final Logger logger = LoggerFactory.getLogger(SmppSessionUtil.class);
 
     static public void close(SmppSession session) {

--- a/src/main/java/com/cloudhopper/smpp/util/SmppUtil.java
+++ b/src/main/java/com/cloudhopper/smpp/util/SmppUtil.java
@@ -31,6 +31,8 @@ import com.cloudhopper.smpp.SmppConstants;
  */
 public class SmppUtil {
 
+    private SmppUtil() {}
+    
     /**
      * Does the "esm_class" value have a message type set at all?  This basically
      * checks if the "esm_class" could either be SMSC delivery receipt, ESME delivery receipt,

--- a/src/main/java/com/cloudhopper/smpp/util/TlvUtil.java
+++ b/src/main/java/com/cloudhopper/smpp/util/TlvUtil.java
@@ -30,6 +30,8 @@ import java.io.UnsupportedEncodingException;
  * @author joelauer (twitter: @jjlauer or <a href="http://twitter.com/jjlauer" target=window>http://twitter.com/jjlauer</a>)
  */
 public class TlvUtil {
+    
+    private TlvUtil() {}
 
     /**
      * Writes a variable length C-String (null terminated) TLV.  If the String


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal Hameed
